### PR TITLE
Update detectdisplays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# detectdisplays
+
+This is a command-line program to do the equivalent of OS X's Detect Displays (found by holding down option in the Displays preference pane inside System Preferences). It takes no arguments and displays no help—just run it.
+
+## Deprecation
+
+As of this writing (2016-01-02), it now builds on OS X 10.11.12 'El Capitan' but has a deprecation warning going back to 'Mavericks'; I would not expect it to continue working for many revisions in the future.
+
+## Building
+
+To build, open _detectdisplays.xcodeproj_ in XCode, then run Build (⌘B). Assuming no errors, to find the executable, click the disclosure triangle next to _Products_ in the left sidebar, then right- or control-click on _detectdisplays_ and select "Reveal in Finder". Copy the executable to somewhere in your PATH.
+
+## Running as a LaunchAgent
+
+_(Moved from the archived wiki at [Google Code](https://code.google.com/p/detectdisplays/wiki/LaunchAgent).)_
+
+To run this LaunchAgent, place this file at `/Library/LaunchAgents/edu.umich.detectdisplays.plist`.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>Label</key>
+        <string>edu.umich.detectdisplays</string>
+        <key>Program</key>
+        <string>/usr/local/bin/detectdisplays</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+</dict>
+</plist>
+```

--- a/detectdisplays.xcodeproj/project.pbxproj
+++ b/detectdisplays.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -112,11 +112,16 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "University of Michigan";
 			};
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "detectdisplays" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* detectdisplays */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -149,6 +154,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = detectdisplays;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -160,32 +166,32 @@
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = detectdisplays;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
 		1DEB928A08733DD80010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		1DEB928B08733DD80010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I've updated detectdisplays to build on El Capitan and added a README.md. It has a deprecation warning about `CGDisplayIOServicePort` that I don't know how to fix, but this may still be useful to someone.
